### PR TITLE
DDCE-5380: Update HMRC logo

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
   val bootstrapVersion = "7.23.0"
 
   private lazy val compile = Seq(
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"             % "7.29.0-play-28",
+    "uk.gov.hmrc"             %% "play-frontend-hmrc-play-28"     % "8.5.0",
     "uk.gov.hmrc"             %% "domain"                         % "8.3.0-play-28",
     "uk.gov.hmrc"             %% "play-conditional-form-mapping"  % "1.13.0-play-28",
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28"     % bootstrapVersion,
@@ -15,9 +15,9 @@ object AppDependencies {
   private lazy val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                 %% "bootstrap-test-play-28"   % bootstrapVersion,
     "org.jsoup"                   %  "jsoup"                    % "1.17.2",
-    "org.scalatest"               %% "scalatest"                % "3.2.17",
+    "org.scalatest"               %% "scalatest"                % "3.2.18",
     "org.mockito"                 %% "mockito-scala-scalatest"  % "1.17.30",
-    "org.wiremock"                %  "wiremock-standalone"      % "3.3.1",
+    "org.wiremock"                % "wiremock-standalone"       % "3.4.2",
     "io.github.wolfendale"        %% "scalacheck-gen-regexp"    % "1.1.0",
     "org.scalatestplus"           %% "scalacheck-1-17"          % "3.2.17.0",
     "com.vladsch.flexmark"        %  "flexmark-all"             % "0.64.8"


### PR DESCRIPTION
Screenshots before/after update to `play-frontend-hmrc v8.5.0`:
![Screenshot 2024-02-29 at 16 33 34](https://github.com/hmrc/register-trust-trustee-frontend/assets/125281117/07d5e81a-3877-4ddc-9c1d-d1b3555979cc)
![Screenshot 2024-02-29 at 16 43 26](https://github.com/hmrc/register-trust-trustee-frontend/assets/125281117/c16f7d0b-2220-4950-bf2e-6f00a362ac34)



